### PR TITLE
fix: Pricing details to reflect recent changes

### DIFF
--- a/src/routes/pricing/+page.svelte
+++ b/src/routes/pricing/+page.svelte
@@ -84,29 +84,6 @@
                     </div>
                     <p class="ml-3 text-sm text-gray-700">Community of like-minded Developers</p>
                   </li>
-
-                  <li class="flex items-start lg:col-span-1">
-                    <div class="flex-shrink-0">
-                      <!-- Heroicon name: check-circle -->
-                      <svg
-                        class="w-5 h-5 text-green-400"
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 20 20"
-                        fill="currentColor"
-                        aria-hidden="true">
-                        <path
-                          fill-rule="evenodd"
-                          d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0
-                          00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414
-                          1.414l2 2a1 1 0 001.414 0l4-4z"
-                          clip-rule="evenodd" />
-                      </svg>
-                    </div>
-                    <p class="ml-3 text-sm text-gray-700">
-                      Completion certificate
-                    </p>
-                  </li>
-
                   <li class="flex items-start lg:col-span-1">
                     <div class="flex-shrink-0">
                       <!-- Heroicon name: check-circle -->
@@ -128,8 +105,62 @@
                       A team project for your portfolio
                     </p>
                   </li>
+                  <li></li>
+                  <li></li>
                 </ul>
               </div>
+              <div class="flex items-center">
+                <h4
+                  class="flex-shrink-0 pr-4 text-sm font-semibold tracking-wider text-green-600 uppercase bg-white">
+                  Completion Certificate with one of the following
+                </h4>
+                <div class="flex-1 border-t-2 border-gray-200" />
+              </div>
+              <ul
+                  class="mt-8 space-y-5 lg:space-y-0 lg:grid lg:grid-cols-2 lg:gap-x-8 lg:gap-y-5">
+                  <li class="flex items-start lg:col-span-1">
+                    <div class="flex-shrink-0">
+                      <!-- Heroicon name: check-circle -->
+                      <svg
+                        class="w-5 h-5 text-green-400"
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 20 20"
+                        fill="currentColor"
+                        aria-hidden="true">
+                        <path
+                          fill-rule="evenodd"
+                          d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0
+                          00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414
+                          1.414l2 2a1 1 0 001.414 0l4-4z"
+                          clip-rule="evenodd" />
+                      </svg>
+                    </div>
+                    <p class="ml-3 text-sm text-gray-700">
+                      One time purchase ($3.99,- USD)
+                    </p>
+                  </li>
+                  <li class="flex items-start lg:col-span-1">
+                    <div class="flex-shrink-0">
+                      <!-- Heroicon name: check-circle -->
+                      <svg
+                        class="w-5 h-5 text-green-400"
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 20 20"
+                        fill="currentColor"
+                        aria-hidden="true">
+                        <path
+                          fill-rule="evenodd"
+                          d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0
+                          00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414
+                          1.414l2 2a1 1 0 001.414 0l4-4z"
+                          clip-rule="evenodd" />
+                      </svg>
+                    </div>
+                    <p class="ml-3 text-sm text-gray-700">
+                      Subscription ($2.99,- USD)
+                    </p>
+                  </li>
+              </ul>
             </div>
             <div
               class="px-6 py-8 text-center bg-gray-50 lg:flex-shrink-0 lg:flex lg:flex-col lg:justify-center lg:p-12">


### PR DESCRIPTION
Remove certificate from included section
Add completion certificate section and the two price points


This can probably be done better, but we need to reflect the new changes to cert pricing as not to misslead new members